### PR TITLE
add support for undo/redo operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
             - name: Unit tests
               run: npm run test:ci
 
+            - name: Lint
+              run: npm run lint
+
             - name: Create build
               run: npm run build
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 npm run test:ci
+npm run lint
 npm run build

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,28 +1,46 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
-  {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
-    files: ['**/*.{ts,tsx}'],
-    languageOptions: {
-      ecmaVersion: 2020,
-      globals: globals.browser,
+    { ignores: ['dist'] },
+    {
+        extends: [js.configs.recommended, ...tseslint.configs.recommended],
+        files: ['**/*.{ts,tsx}'],
+        languageOptions: {
+            ecmaVersion: 2020,
+            globals: globals.browser,
+        },
+        plugins: {
+            'react-hooks': reactHooks,
+            'react-refresh': reactRefresh,
+        },
+        rules: {
+            ...reactHooks.configs.recommended.rules,
+            '@typescript-eslint/no-empty-object-type': ['off'],
+            'react-refresh/only-export-components': [
+                'warn',
+                { allowConstantExport: true },
+            ],
+        },
     },
-    plugins: {
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
-    },
-    rules: {
-      ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
-    },
-  },
-)
+    {
+        extends: [js.configs.recommended, ...tseslint.configs.recommended],
+        files: ['src/components/ui/**/*.{ts,tsx}'],
+        languageOptions: {
+            ecmaVersion: 2020,
+            globals: globals.browser,
+        },
+        plugins: {
+            'react-hooks': reactHooks,
+            'react-refresh': reactRefresh,
+        },
+        rules: {
+            ...reactHooks.configs.recommended.rules,
+            '@typescript-eslint/no-empty-object-type': ['off'],
+            'react-refresh/only-export-components': ['off'],
+        },
+    }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.17.0",
+                "@testing-library/jest-dom": "^7.0.0",
+                "@testing-library/react": "^16.3.2",
                 "@types/jest": "^30.0.0",
                 "@types/node": "^24.6.2",
                 "@types/react": "^18.3.18",
@@ -30,6 +32,7 @@
                 "eslint-plugin-react-refresh": "^0.4.16",
                 "globals": "^15.14.0",
                 "husky": "^9.1.7",
+                "jsdom": "^27.0.1",
                 "pixelmatch": "^7.1.0",
                 "pngjs": "^7.0.0",
                 "prettier": "^3.9.5",
@@ -38,6 +41,13 @@
                 "vite": "^6.0.5",
                 "vitest": "^3.2.4"
             }
+        },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+            "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@ark-ui/react": {
             "version": "5.25.1",
@@ -111,6 +121,41 @@
                 "react": ">=18.0.0",
                 "react-dom": ">=18.0.0"
             }
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+            "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^3.0.0",
+                "@csstools/css-color-parser": "^4.0.1",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0",
+                "lru-cache": "^11.2.5"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+            "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.1.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.6"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.27.1",
@@ -270,6 +315,146 @@
                 "@emotion/react": ">=11",
                 "react": ">=18",
                 "react-dom": ">=18"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+            "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+            "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+            "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.1.0",
+                "@csstools/css-calc": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+            "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@cypress/request": {
@@ -1854,6 +2039,131 @@
                 "@swc/counter": "^0.1.3"
             }
         },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/@testing-library/dom/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+            "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@adobe/css-tools": "^4.4.0",
+                "aria-query": "^5.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "picocolors": "^1.1.1",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=22",
+                "npm": ">=6",
+                "yarn": ">=1"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=10 <11"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
+        },
         "node_modules/@types/chai": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -3286,6 +3596,16 @@
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -3409,6 +3729,16 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true,
             "license": "Python-2.0"
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
         },
         "node_modules/asn1": {
             "version": "0.2.6",
@@ -3542,6 +3872,16 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tweetnacl": "^0.14.3"
+            }
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/bl": {
@@ -3975,6 +4315,43 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cssstyle": {
+            "version": "5.3.7",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+            "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^4.1.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+                "css-tree": "^3.1.0",
+                "lru-cache": "^11.2.4"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -4070,6 +4447,30 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/data-urls": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+            "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^15.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/dayjs": {
             "version": "1.11.19",
             "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -4093,6 +4494,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/decompress-response": {
             "version": "6.0.0",
@@ -4147,6 +4555,16 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/detect-libc": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4156,6 +4574,14 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
@@ -4212,6 +4638,19 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/error-ex": {
@@ -5116,6 +5555,33 @@
                 "react-is": "^16.7.0"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/http-signature": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
@@ -5129,6 +5595,20 @@
             },
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -5155,6 +5635,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/typicode"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/ieee754": {
@@ -5331,6 +5824,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-stream": {
             "version": "2.0.1",
@@ -5513,6 +6013,79 @@
             "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "27.0.1",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+            "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/dom-selector": "^6.7.2",
+                "cssstyle": "^5.3.1",
+                "data-urls": "^6.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^8.0.0",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^15.1.0",
+                "ws": "^8.18.3",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/tldts": {
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+            "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.4.9"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/jsdom/node_modules/tldts-core": {
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+            "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsdom/node_modules/tough-cookie": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+            "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -5789,6 +6362,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lru-cache": {
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.19",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -5808,6 +6402,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -5884,6 +6485,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/minimatch": {
@@ -6138,6 +6749,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
         "node_modules/path-exists": {
@@ -6573,6 +7197,20 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/request-progress": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -6581,6 +7219,16 @@
             "license": "MIT",
             "dependencies": {
                 "throttleit": "^1.0.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/resolve": {
@@ -6686,6 +7334,13 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/rrweb-cssom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6747,6 +7402,19 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
         },
         "node_modules/scheduler": {
             "version": "0.23.2",
@@ -7085,6 +7753,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7148,6 +7829,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tar-fs": {
             "version": "2.1.4",
@@ -7342,6 +8030,19 @@
             },
             "engines": {
                 "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/tree-kill": {
@@ -7744,6 +8445,67 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+            "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7811,6 +8573,45 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/ws": {
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/yaml": {
             "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.6.2",
         "@types/react": "^18.3.18",
@@ -37,6 +39,7 @@
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
         "husky": "^9.1.7",
+        "jsdom": "^27.0.1",
         "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0",
         "prettier": "^3.9.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import {
     Link,
     NumberInput,
     parseColor,
+    RadioCard,
     Separator,
     Spinner,
     Stack,
@@ -49,6 +50,7 @@ import { GoTrash } from 'react-icons/go';
 import TresholdingTool from './components/TresholdingTool';
 import LogTransformTool from './components/LogTransformTool';
 import HSLTool from './components/HSLTool';
+import useHistory from './hooks/useOperationsHistory';
 
 const HEADER_HEIGHT = 86;
 
@@ -59,7 +61,6 @@ function App() {
     const [color, setColor] = useState(COLOR.FG2);
     const [diagonals, setDiagonals] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
-    const [image, setImage] = useState<HTMLImageElement | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [shouldShowCellIds, setShouldShowCellIds] = useState<boolean>(false);
     const [aspectRatio, setAspectRatio] = useState<ReturnType<
@@ -67,6 +68,9 @@ function App() {
     > | null>(null);
     const [filename, setFilename] = useState('');
     const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    const history = useHistory();
+    const image = history.snapshot?.image;
 
     const handleDownload = useCallback(() => {
         if (!canvasRef.current) return;
@@ -94,28 +98,28 @@ function App() {
         if (!image) return;
         setIsLoading(true);
         rotateImage(image, -90).then((img) => {
-            setImage(img);
+            history.append('Rotate counterclockwise', img);
             suggestGrids(img);
         });
-    }, [image, suggestGrids]);
+    }, [image, suggestGrids, history.append]);
 
     const handleTurnRight = useCallback(() => {
         if (!image) return;
         setIsLoading(true);
         rotateImage(image, 90).then((img) => {
-            setImage(img);
+            history.append('Rotate clockwise', img);
             suggestGrids(img);
         });
-    }, [image, suggestGrids]);
+    }, [image, suggestGrids, history.append]);
 
-    const handleImageUpdate = useCallback(
-        (image: HTMLImageElement) => {
-            setImage(image);
+    const handleToolSave = useCallback(
+        (image: HTMLImageElement, toolName: string) => {
+            history.append(toolName, image);
             setAspectRatio(getAspectRatio(image.width, image.height));
             suggestGrids(image);
             setIsLoading(true);
         },
-        [suggestGrids]
+        [suggestGrids, history.append]
     );
 
     useEffect(() => {
@@ -283,7 +287,8 @@ function App() {
 
                 const img = new Image();
                 img.onload = () => {
-                    setImage(img);
+                    history.clear();
+                    history.append('Load image', img);
                     suggestGrids(img);
                     setIsLoading(false);
                 };
@@ -295,17 +300,21 @@ function App() {
             };
             reader.readAsDataURL(file);
         },
-        [suggestGrids]
+        [suggestGrids, history.append]
     );
     const handleReflectVertically = useCallback<() => void>(() => {
         if (!image) return;
         setIsLoading(true);
-        mirrorImageVertically(image).then(setImage);
+        mirrorImageVertically(image).then((image) =>
+            handleToolSave(image, 'Reflect vertically')
+        );
     }, [image]);
     const handleReflectHorizontally = useCallback<() => void>(() => {
         if (!image) return;
         setIsLoading(true);
-        mirrorImageHorizontally(image).then(setImage);
+        mirrorImageHorizontally(image).then((image) =>
+            handleToolSave(image, 'Reflect horizontally')
+        );
     }, [image]);
     const handleFilenameChange = useCallback<
         React.ChangeEventHandler<HTMLInputElement>
@@ -481,7 +490,9 @@ function App() {
                             <HStack>
                                 <CroppingTool
                                     image={image}
-                                    onSave={handleImageUpdate}
+                                    onSave={(image) =>
+                                        handleToolSave(image, 'Crop')
+                                    }
                                 />
                                 <Tooltip content="Rotate counterclockwise">
                                     <IconButton
@@ -527,7 +538,7 @@ function App() {
                                     <IconButton
                                         variant="surface"
                                         size="sm"
-                                        onClick={() => setImage(null)}
+                                        onClick={history.clear}
                                         data-test-name="delete-image"
                                     >
                                         <GoTrash />
@@ -537,15 +548,24 @@ function App() {
                             <HStack>
                                 <TresholdingTool
                                     image={image}
-                                    onSave={handleImageUpdate}
+                                    onSave={(image) =>
+                                        handleToolSave(image, 'Tresholding')
+                                    }
                                 />
                                 <LogTransformTool
                                     image={image}
-                                    onSave={handleImageUpdate}
+                                    onSave={(image) =>
+                                        handleToolSave(
+                                            image,
+                                            'Complex transform'
+                                        )
+                                    }
                                 />
                                 <HSLTool
                                     image={image}
-                                    onSave={handleImageUpdate}
+                                    onSave={(image) =>
+                                        handleToolSave(image, 'HSL tool')
+                                    }
                                 />
                             </HStack>
 
@@ -790,6 +810,47 @@ function App() {
                             </HStack>
                         </ColorPicker.Content>
                     </ColorPicker.Root>
+                    {!!history.history.length && (
+                        <>
+                            <Separator margin="8px 0" />
+                            <Heading size="md" color={COLOR.TEXT2}>
+                                History
+                            </Heading>
+                            <RadioCard.Root
+                                size="sm"
+                                value={history.index + ''}
+                                onValueChange={(e) => {
+                                    const value = e.value;
+                                    if (!value) return;
+                                    history.setIndex(+value);
+                                    const snapshot = history.history[+value];
+                                    if (snapshot) suggestGrids(snapshot.image);
+                                }}
+                            >
+                                <Stack align="stretch">
+                                    {history.history.map((item, index) => (
+                                        <RadioCard.Item
+                                            key={index}
+                                            value={index + ''}
+                                        >
+                                            <RadioCard.ItemHiddenInput />
+                                            <RadioCard.ItemControl>
+                                                <RadioCard.ItemText>
+                                                    {item.toolName}
+                                                </RadioCard.ItemText>
+                                                <RadioCard.ItemDescription>
+                                                    {item.date.toLocaleTimeString(
+                                                        'en-GB'
+                                                    )}
+                                                </RadioCard.ItemDescription>
+                                                <RadioCard.ItemIndicator />
+                                            </RadioCard.ItemControl>
+                                        </RadioCard.Item>
+                                    ))}
+                                </Stack>
+                            </RadioCard.Root>
+                        </>
+                    )}
                 </Stack>
                 <HStack position="fixed" bottom="0" right="14px" zIndex={2}>
                     <Text fontSize="0.8em" color="rgba(255, 255, 255, 0.5)">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,28 +98,28 @@ function App() {
         if (!image) return;
         setIsLoading(true);
         rotateImage(image, -90).then((img) => {
-            history.append('Rotate counterclockwise', img);
+            history.add('Rotate counterclockwise', img);
             suggestGrids(img);
         });
-    }, [image, suggestGrids, history.append]);
+    }, [image, suggestGrids, history]);
 
     const handleTurnRight = useCallback(() => {
         if (!image) return;
         setIsLoading(true);
         rotateImage(image, 90).then((img) => {
-            history.append('Rotate clockwise', img);
+            history.add('Rotate clockwise', img);
             suggestGrids(img);
         });
-    }, [image, suggestGrids, history.append]);
+    }, [image, suggestGrids, history]);
 
     const handleToolSave = useCallback(
         (image: HTMLImageElement, toolName: string) => {
-            history.append(toolName, image);
+            history.add(toolName, image);
             setAspectRatio(getAspectRatio(image.width, image.height));
             suggestGrids(image);
             setIsLoading(true);
         },
-        [suggestGrids, history.append]
+        [suggestGrids, history]
     );
 
     useEffect(() => {
@@ -288,7 +288,7 @@ function App() {
                 const img = new Image();
                 img.onload = () => {
                     history.clear();
-                    history.append('Load image', img);
+                    history.add('Load image', img);
                     suggestGrids(img);
                     setIsLoading(false);
                 };
@@ -300,27 +300,31 @@ function App() {
             };
             reader.readAsDataURL(file);
         },
-        [suggestGrids, history.append]
+        [suggestGrids, history]
     );
+
     const handleReflectVertically = useCallback<() => void>(() => {
         if (!image) return;
         setIsLoading(true);
         mirrorImageVertically(image).then((image) =>
             handleToolSave(image, 'Reflect vertically')
         );
-    }, [image]);
+    }, [image, handleToolSave]);
+
     const handleReflectHorizontally = useCallback<() => void>(() => {
         if (!image) return;
         setIsLoading(true);
         mirrorImageHorizontally(image).then((image) =>
             handleToolSave(image, 'Reflect horizontally')
         );
-    }, [image]);
+    }, [image, handleToolSave]);
+
     const handleFilenameChange = useCallback<
         React.ChangeEventHandler<HTMLInputElement>
     >((e) => {
         setFilename(e.target.value);
     }, []);
+
     return (
         <Box
             display="flex"

--- a/src/__tests__/hooks/useOperationsHistory.test.ts
+++ b/src/__tests__/hooks/useOperationsHistory.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useOperationsHistory from '@/hooks/useOperationsHistory';
+
+describe('useOperationsHistory', () => {
+    test('history is empty by default', () => {
+        const { result } = renderHook(() => useOperationsHistory());
+        expect(result.current.history.length).toBe(0);
+    });
+    test('undo works as expected', () => {
+        const { result } = renderHook(() => useOperationsHistory());
+        const img = new Image();
+
+        act(() => {
+            result.current.add('load image', img);
+            result.current.add('do nothing', img);
+        });
+        expect(result.current.snapshot.toolName).toBe('do nothing');
+
+        act(() => {
+            result.current.undo();
+        });
+        expect(result.current.snapshot.toolName).toBe('load image');
+
+        act(() => {
+            result.current.undo();
+        });
+        expect(result.current.snapshot.toolName).toBe('load image');
+    });
+    test('redo works as expected', () => {
+        const { result } = renderHook(() => useOperationsHistory());
+        const img = new Image();
+
+        act(() => {
+            result.current.add('load image', img);
+            result.current.add('do nothing', img);
+        });
+        act(() => {
+            result.current.setIndex(0);
+        });
+        expect(result.current.snapshot.toolName).toBe('load image');
+
+        act(() => {
+            result.current.redo();
+        });
+        expect(result.current.snapshot.toolName).toBe('do nothing');
+
+        act(() => {
+            result.current.redo();
+        });
+        expect(result.current.snapshot.toolName).toBe('do nothing');
+    });
+    test('clear works as expected', () => {
+        const { result } = renderHook(() => useOperationsHistory());
+        const img = new Image();
+        act(() => {
+            result.current.add('load image', img);
+            result.current.add('do nothing', img);
+        });
+        expect(result.current.history.length).toBe(2);
+        expect(result.current.snapshot.toolName).toBe('do nothing');
+        act(() => {
+            result.current.clear();
+        });
+        expect(result.current.history.length).toBe(0);
+        expect(result.current.snapshot).toBe(undefined);
+    });
+    test('add adds new entry', () => {
+        const { result } = renderHook(() => useOperationsHistory());
+        expect(result.current.index).toBe(0);
+        const catA = new Image();
+        const catB = new Image();
+        const catC = new Image();
+        act(() => {
+            result.current.add('meow', catA);
+        });
+        expect(result.current.snapshot.toolName).toBe('meow');
+        expect(result.current.snapshot.image).toBe(catA);
+        expect(result.current.index).toBe(0);
+
+        act(() => {
+            result.current.add('meoww', catB);
+        });
+        expect(result.current.snapshot.toolName).toBe('meoww');
+        expect(result.current.snapshot.image).toBe(catB);
+        expect(result.current.index).toBe(1);
+
+        act(() => {
+            result.current.add('meowww', catC);
+        });
+        expect(result.current.snapshot.toolName).toBe('meowww');
+        expect(result.current.snapshot.image).toBe(catC);
+        expect(result.current.index).toBe(2);
+    });
+    test('add adds new entry when index is not the last available index', () => {
+        const { result } = renderHook(() => useOperationsHistory());
+        const catA = new Image();
+        const catB = new Image();
+        const catC = new Image();
+
+        act(() => {
+            result.current.add('meow', catA);
+            result.current.add('meoww', catB);
+        });
+        act(() => {
+            result.current.setIndex(0);
+        });
+        expect(result.current.snapshot.toolName).toBe('meow');
+        expect(result.current.snapshot.image).toBe(catA);
+
+        act(() => {
+            result.current.add('meowww', catC);
+        });
+        // cat B is expected to be removed:
+        expect(result.current.snapshot.toolName).toBe('meowww');
+        expect(result.current.snapshot.image).toBe(catC);
+        expect(result.current.history.length).toBe(2);
+        expect(result.current.history[0].toolName).toBe('meow');
+        expect(result.current.history[1].toolName).toBe('meowww');
+    });
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -37,14 +37,14 @@ describe('getAspectRatio', () => {
             factorFound,
         ]) => {
             expect(
-                getAspectRatio(width as number, height as number),
+                getAspectRatio(width as number, height as number)
             ).toStrictEqual<Result>({
                 factorFound: factorFound as boolean,
                 label: `${expectedWidthComponent}:${expectedHeightComponent}`,
                 widthComponent: expectedWidthComponent as number,
                 heightComponent: expectedHeightComponent as number,
             });
-        },
+        }
     );
     it('prime:prime -> finds a close aspect ratio', () => {
         const primeA = 20 ** 2 - 1;
@@ -53,7 +53,7 @@ describe('getAspectRatio', () => {
         expect(result.factorFound).toBe(true);
         expect(result.label).toBe('4:9');
         expect(
-            (result.widthComponent / result.heightComponent).toFixed(2),
+            (result.widthComponent / result.heightComponent).toFixed(2)
         ).toBe((primeA / primeB).toFixed(2));
     });
 });
@@ -78,14 +78,14 @@ describe('getGridSuggestion', () => {
             expect(getGridSuggestion(img)).toStrictEqual<GridSuggestion>({
                 aspectRatio: getAspectRatio(
                     img.naturalWidth,
-                    img.naturalHeight,
+                    img.naturalHeight
                 ),
                 grid: {
                     rows: expectedRows as number,
                     columns: expectedColumns as number,
                 },
             });
-        },
+        }
     );
 });
 
@@ -98,7 +98,7 @@ describe('getLineThicknessSuggestion', () => {
         [2001, 100, 3],
     ])('%i:%i -> %ipx', ([width, height, expectedLineThickness]) => {
         expect(getLineThicknessSuggestion(width, height)).toBe(
-            expectedLineThickness,
+            expectedLineThickness
         );
     });
 });
@@ -150,6 +150,7 @@ describe('thresholdImage', () => {
             0, 0, 0, 255,
         ]);
 
-        expect(result.data).toEqual(expected);
+        // ...x - workaround for test issue (mixed ImageData implementations jsdom vs canvas)
+        expect([...result.data]).toEqual([...expected]);
     });
 });

--- a/src/components/CroppingTool/index.tsx
+++ b/src/components/CroppingTool/index.tsx
@@ -99,8 +99,8 @@ const CroppingTool = ({ image, onSave }: Props) => {
         }
         const x1 = width * 0.1;
         const y1 = height * 0.1;
-        let x2 = width * 0.9;
-        let y2 = height * 0.9;
+        const x2 = width * 0.9;
+        const y2 = height * 0.9;
 
         setStartPoint({
             x: x1,
@@ -119,6 +119,22 @@ const CroppingTool = ({ image, onSave }: Props) => {
         aspectRatio.heightComponent,
     ]);
 
+    const renderBackdrop = useCallback(() => {
+        const canvasOverlay = canvasOverlayRef.current;
+        if (!canvasOverlay) return;
+        const overlayCtx = canvasOverlay.getContext('2d');
+        if (!overlayCtx) return;
+
+        const w = canvasOverlay.width;
+        const h = canvasOverlay.height;
+        const { x1, x2, y1, y2 } = area.current;
+
+        overlayCtx.clearRect(0, 0, w, h);
+        overlayCtx.fillStyle = '#0000006e';
+        overlayCtx.fillRect(0, 0, w, h);
+        overlayCtx.clearRect(x1, y1, x2 - x1, y2 - y1);
+    }, []);
+
     const handleResetPoints = useCallback(() => {
         setupInitialCropArea();
         renderBackdrop();
@@ -129,7 +145,7 @@ const CroppingTool = ({ image, onSave }: Props) => {
         });
         setOrientation('horizontal');
         setRatioOption('1:1');
-    }, [image]);
+    }, [renderBackdrop, setupInitialCropArea]);
 
     const handleClose = useCallback(() => {
         handleResetPoints();
@@ -161,22 +177,6 @@ const CroppingTool = ({ image, onSave }: Props) => {
         tempCtx.putImageData(imageData, 0, 0);
         img.src = tempCanvas.toDataURL();
     }, [onSave, image, startPoint, endPoint, handleClose]);
-
-    const renderBackdrop = useCallback(() => {
-        const canvasOverlay = canvasOverlayRef.current;
-        if (!canvasOverlay) return;
-        const overlayCtx = canvasOverlay.getContext('2d');
-        if (!overlayCtx) return;
-
-        const w = canvasOverlay.width;
-        const h = canvasOverlay.height;
-        const { x1, x2, y1, y2 } = area.current;
-
-        overlayCtx.clearRect(0, 0, w, h);
-        overlayCtx.fillStyle = '#0000006e';
-        overlayCtx.fillRect(0, 0, w, h);
-        overlayCtx.clearRect(x1, y1, x2 - x1, y2 - y1);
-    }, []);
 
     useEffect(() => {
         setupInitialCropArea();
@@ -564,6 +564,7 @@ const CroppingTool = ({ image, onSave }: Props) => {
         aspectRatio.force,
         aspectRatio.widthComponent,
         aspectRatio.heightComponent,
+        renderBackdrop,
     ]);
     const perceivedImageWidth =
         (image.naturalWidth / image.naturalHeight) * CANVAS_HEIGHT;

--- a/src/components/ui/color-mode.tsx
+++ b/src/components/ui/color-mode.tsx
@@ -1,108 +1,108 @@
-"use client"
+'use client';
 
-import type { IconButtonProps, SpanProps } from "@chakra-ui/react"
-import { ClientOnly, IconButton, Skeleton, Span } from "@chakra-ui/react"
-import { ThemeProvider, useTheme } from "next-themes"
-import type { ThemeProviderProps } from "next-themes"
-import * as React from "react"
-import { LuMoon, LuSun } from "react-icons/lu"
+import type { IconButtonProps, SpanProps } from '@chakra-ui/react';
+import { ClientOnly, IconButton, Skeleton, Span } from '@chakra-ui/react';
+import { ThemeProvider, useTheme } from 'next-themes';
+import type { ThemeProviderProps } from 'next-themes';
+import * as React from 'react';
+import { LuMoon, LuSun } from 'react-icons/lu';
 
 export interface ColorModeProviderProps extends ThemeProviderProps {}
 
 export function ColorModeProvider(props: ColorModeProviderProps) {
-  return (
-    <ThemeProvider attribute="class" disableTransitionOnChange {...props} />
-  )
+    return (
+        <ThemeProvider attribute="class" disableTransitionOnChange {...props} />
+    );
 }
 
-export type ColorMode = "light" | "dark"
+export type ColorMode = 'light' | 'dark';
 
 export interface UseColorModeReturn {
-  colorMode: ColorMode
-  setColorMode: (colorMode: ColorMode) => void
-  toggleColorMode: () => void
+    colorMode: ColorMode;
+    setColorMode: (colorMode: ColorMode) => void;
+    toggleColorMode: () => void;
 }
 
 export function useColorMode(): UseColorModeReturn {
-  const { resolvedTheme, setTheme, forcedTheme } = useTheme()
-  const colorMode = forcedTheme || resolvedTheme
-  const toggleColorMode = () => {
-    setTheme(resolvedTheme === "dark" ? "light" : "dark")
-  }
-  return {
-    colorMode: colorMode as ColorMode,
-    setColorMode: setTheme,
-    toggleColorMode,
-  }
+    const { resolvedTheme, setTheme, forcedTheme } = useTheme();
+    const colorMode = forcedTheme || resolvedTheme;
+    const toggleColorMode = () => {
+        setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+    };
+    return {
+        colorMode: colorMode as ColorMode,
+        setColorMode: setTheme,
+        toggleColorMode,
+    };
 }
 
 export function useColorModeValue<T>(light: T, dark: T) {
-  const { colorMode } = useColorMode()
-  return colorMode === "dark" ? dark : light
+    const { colorMode } = useColorMode();
+    return colorMode === 'dark' ? dark : light;
 }
 
 export function ColorModeIcon() {
-  const { colorMode } = useColorMode()
-  return colorMode === "dark" ? <LuMoon /> : <LuSun />
+    const { colorMode } = useColorMode();
+    return colorMode === 'dark' ? <LuMoon /> : <LuSun />;
 }
 
-interface ColorModeButtonProps extends Omit<IconButtonProps, "aria-label"> {}
+interface ColorModeButtonProps extends Omit<IconButtonProps, 'aria-label'> {}
 
 export const ColorModeButton = React.forwardRef<
-  HTMLButtonElement,
-  ColorModeButtonProps
+    HTMLButtonElement,
+    ColorModeButtonProps
 >(function ColorModeButton(props, ref) {
-  const { toggleColorMode } = useColorMode()
-  return (
-    <ClientOnly fallback={<Skeleton boxSize="9" />}>
-      <IconButton
-        onClick={toggleColorMode}
-        variant="ghost"
-        aria-label="Toggle color mode"
-        size="sm"
-        ref={ref}
-        {...props}
-        css={{
-          _icon: {
-            width: "5",
-            height: "5",
-          },
-        }}
-      >
-        <ColorModeIcon />
-      </IconButton>
-    </ClientOnly>
-  )
-})
+    const { toggleColorMode } = useColorMode();
+    return (
+        <ClientOnly fallback={<Skeleton boxSize="9" />}>
+            <IconButton
+                onClick={toggleColorMode}
+                variant="ghost"
+                aria-label="Toggle color mode"
+                size="sm"
+                ref={ref}
+                {...props}
+                css={{
+                    _icon: {
+                        width: '5',
+                        height: '5',
+                    },
+                }}
+            >
+                <ColorModeIcon />
+            </IconButton>
+        </ClientOnly>
+    );
+});
 
 export const LightMode = React.forwardRef<HTMLSpanElement, SpanProps>(
-  function LightMode(props, ref) {
-    return (
-      <Span
-        color="fg"
-        display="contents"
-        className="chakra-theme light"
-        colorPalette="gray"
-        colorScheme="light"
-        ref={ref}
-        {...props}
-      />
-    )
-  },
-)
+    function LightMode(props, ref) {
+        return (
+            <Span
+                color="fg"
+                display="contents"
+                className="chakra-theme light"
+                colorPalette="gray"
+                colorScheme="light"
+                ref={ref}
+                {...props}
+            />
+        );
+    }
+);
 
 export const DarkMode = React.forwardRef<HTMLSpanElement, SpanProps>(
-  function DarkMode(props, ref) {
-    return (
-      <Span
-        color="fg"
-        display="contents"
-        className="chakra-theme dark"
-        colorPalette="gray"
-        colorScheme="dark"
-        ref={ref}
-        {...props}
-      />
-    )
-  },
-)
+    function DarkMode(props, ref) {
+        return (
+            <Span
+                color="fg"
+                display="contents"
+                className="chakra-theme dark"
+                colorPalette="gray"
+                colorScheme="dark"
+                ref={ref}
+                {...props}
+            />
+        );
+    }
+);

--- a/src/hooks/useOperationsHistory.ts
+++ b/src/hooks/useOperationsHistory.ts
@@ -6,43 +6,61 @@ type Snapshot = {
     date: Date;
 };
 
-// TODO - fix lint in IDE to show missing vars in dependency arrays
+type State = {
+    index: number;
+    history: Snapshot[];
+};
 
-// TODO - cover with tests!
 const useOperationsHistory = () => {
-    const [history, setHistory] = useState<Snapshot[]>([]);
-    const [index, setIndex] = useState<number>(0);
+    const [state, setState] = useState<State>({
+        index: 0,
+        history: [],
+    });
 
-    const append = useCallback((toolName: string, image: HTMLImageElement) => {
-        setHistory((history) => {
-            setIndex((index) => {
-                if (!history.length) return 0;
-                return index + 1; // TODO - it will not be true if index is not the last item!!!
+    const setIndex = useCallback((index: number) => {
+        setState((old) => ({ ...old, index }));
+    }, []);
+
+    const add = useCallback((toolName: string, image: HTMLImageElement) => {
+        setState((old) => {
+            // everything after index gets removed
+            const index = old.history.length === 0 ? 0 : old.index + 1;
+            const history = old.history.slice(0, index);
+            history.push({
+                toolName,
+                image,
+                date: new Date(),
             });
-            return [
-                ...history,
-                {
-                    toolName,
-                    image,
-                    date: new Date(),
-                },
-            ];
+            return {
+                ...old,
+                index,
+                history,
+            };
         });
     }, []);
 
     const clear = useCallback(() => {
-        setHistory(() => []);
-        setIndex(() => 0);
+        setState(() => ({
+            history: [],
+            index: 0,
+        }));
     }, []);
 
     const undo = useCallback(() => {
-        setIndex((old) => Math.max(0, old - 1));
+        setState((old) => ({
+            ...old,
+            index: Math.max(0, old.index - 1),
+        }));
     }, []);
 
     const redo = useCallback(() => {
-        setIndex((old) => Math.min(old + 1, history.length - 1));
-    }, [history.length]);
+        setState((old) => ({
+            ...old,
+            index: Math.min(old.index + 1, old.history.length - 1),
+        }));
+    }, []);
 
+    const { history, index } = state;
     const snapshot: Snapshot | null = history[index];
 
     useEffect(() => {
@@ -63,7 +81,7 @@ const useOperationsHistory = () => {
 
     return {
         clear,
-        append,
+        add,
         undo,
         redo,
         index,

--- a/src/hooks/useOperationsHistory.ts
+++ b/src/hooks/useOperationsHistory.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from 'react';
+
+type Snapshot = {
+    toolName: string;
+    image: HTMLImageElement;
+    date: Date;
+};
+
+// TODO - fix lint in IDE to show missing vars in dependency arrays
+
+// TODO - cover with tests!
+const useOperationsHistory = () => {
+    const [history, setHistory] = useState<Snapshot[]>([]);
+    const [index, setIndex] = useState<number>(0);
+
+    const append = useCallback((toolName: string, image: HTMLImageElement) => {
+        setHistory((history) => {
+            setIndex((index) => {
+                if (!history.length) return 0;
+                return index + 1; // TODO - it will not be true if index is not the last item!!!
+            });
+            return [
+                ...history,
+                {
+                    toolName,
+                    image,
+                    date: new Date(),
+                },
+            ];
+        });
+    }, []);
+
+    const clear = useCallback(() => {
+        setHistory(() => []);
+        setIndex(() => 0);
+    }, []);
+
+    const undo = useCallback(() => {
+        setIndex((old) => Math.max(0, old - 1));
+    }, []);
+
+    const redo = useCallback(() => {
+        setIndex((old) => Math.min(old + 1, history.length - 1));
+    }, [history.length]);
+
+    const snapshot: Snapshot | null = history[index];
+
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.ctrlKey || e.metaKey) {
+                if (e.key.toLowerCase() === 'z') {
+                    undo();
+                } else if (e.key.toLowerCase() === 'y') {
+                    redo();
+                }
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [undo, redo]);
+
+    return {
+        clear,
+        append,
+        undo,
+        redo,
+        index,
+        setIndex,
+        history,
+        snapshot,
+    };
+};
+
+export default useOperationsHistory;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="vitest/config" />
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import path from 'path';
@@ -16,5 +18,11 @@ export default defineConfig({
     },
     define: {
         __COMMIT_HASH__: JSON.stringify(commitHash),
+    },
+
+    test: {
+        environment: 'jsdom',
+        globals: true,
+        setupFiles: './src/__tests__/setup.ts',
     },
 });


### PR DESCRIPTION
https://github.com/Zazzik1/image-grid-tool/issues/22

- Added undo/redo operations
  - users can use ctrl+z and ctrl+y,
  - users can select the snapshot by clicking the appropriate radio card in ui.
- Fixed lint and added it in precommit and CI pipelines
  - disabled some lint rules for the directory `components/ui` (auto-generated by chakra CLI)
- Added RTL and jsdom

The operations history can be found in the bottom right corner:

<img width="1905" height="904" alt="Zrzut ekranu 2026-07-27 154802" src="https://github.com/user-attachments/assets/33d94363-a610-44f0-84de-3e7e23b69908" />
